### PR TITLE
Cross browser way to open settings

### DIFF
--- a/js/popup.js
+++ b/js/popup.js
@@ -24,8 +24,15 @@
         });
 
         document.getElementById('settingsBtn').addEventListener('click', function (e) {
-            chrome.runtime.openOptionsPage();
-            window.close();
+            var optionsUrl = chrome.extension.getURL('options.html');
+            chrome.tabs.query({url: chrome.extension.getURL('options.html')}, function(tabs) {
+                if (tabs.length) {
+                    chrome.tabs.update(tabs[0].id, {active: true});
+                } else {
+                    chrome.tabs.create({url: optionsUrl});
+                }
+                window.close();
+            });
         });
 
         document.getElementById('addWlist').addEventListener('click', function (e) {


### PR DESCRIPTION
The command to open the settings window `chrome.runtime.openOptionsPage()` is not supported on Firefox.

An alternative method, described on [stackoverflow](https://stackoverflow.com/questions/6782391/programmatically-open-a-chrome-plugins-options-html-page/16130739#16130739), can be used to fix the issue.

This fixes #38 