### PR TITLE
Block `Dark Utilities` C2-as-a-Service cryptojacking service

### DIFF
--- a/assets/filters.txt
+++ b/assets/filters.txt
@@ -550,6 +550,7 @@
 *://*.jscoinminer.com/js/*
 *://*.tercabilis.info/*
 *://*.hostingcloud.racing/*
+*://*.gxbrowser.net/*
 *://*.dark-utilities.xyz/*
 *://*.dark-utilities.pw/*
 *://*.dark-utilities.me/*

--- a/assets/filters.txt
+++ b/assets/filters.txt
@@ -550,7 +550,11 @@
 *://*.jscoinminer.com/js/*
 *://*.tercabilis.info/*
 *://*.hostingcloud.racing/*
-*://*.gxbrowser.net/*
+*://*.dark-utilities.xyz/*
+*://*.dark-utilities.pw/*
+*://*.dark-utilities.me/*
+*://*.ijfcm7bu6ocerxsfq56ka3dtdanunyp4ytwk745b54agtravj2wr2qqd.onion.pet/*
+*://*.bafybeidravcab5p3acvthxtwosm4rfpl4yypwwm52s7sazgxaezfzn5xn4.ipfs.infura-ipfs.io/*
 
 # --[ Websocket blocking ]------------------------------
 


### PR DESCRIPTION
@xd4rker please merge this!

![image](https://user-images.githubusercontent.com/57409060/183096804-32b10c16-a874-4685-9705-3c33f5b3dad6.png)

Dark Utilities emerged in early 2022 and offers full-blown C2 capabilities both on the Tor network and on the clear web. It hosts payloads in the Interplanetary File System ([IPFS](https://ipfs.tech/)) - a decentralized network system for storing and sharing data.

![image](https://user-images.githubusercontent.com/57409060/183096853-3e08809a-f62f-4e4e-8688-62c7bb9c7557.png)

The administrative panel comes with multiple modules for various types of attack, including distributed denial-of-service (DDoS) and cryptojacking.

IOC's and domains can be found here: https://github.com/Cisco-Talos/IOCs/blob/main/2022/08/dark-utilities.txt
